### PR TITLE
docs: apply C1 rebrand to connector.mdx

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a Grafana connector"
 og:title: "Set up a Grafana connector"
-description: "ConductorOne provides identity governance and just-in-time provisioning for Grafana. Integrate your Grafana instance with ConductorOne to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "ConductorOne provides identity governance and just-in-time provisioning for Grafana. Integrate your Grafana instance with ConductorOne to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance and just-in-time provisioning for Grafana. Integrate your Grafana instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance and just-in-time provisioning for Grafana. Integrate your Grafana instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Grafana"
 ---
 
@@ -10,27 +10,27 @@ sidebarTitle: "Grafana"
 
 | Resource | Sync | Provision |
 | :--- | :--- | :--- |
-| Accounts | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
-| Organizations | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
+| Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Organizations | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 
 The Grafana connector supports both **self-hosted Grafana** instances and **Grafana Cloud**. The required credentials and provisioning behavior differ between the two — see [Gather Grafana credentials](#gather-grafana-credentials) below.
 
 The Grafana connector supports [automatic account provisioning and deprovisioning](/product/admin/account-provisioning).
 
-For self-hosted Grafana, when a new account is created by ConductorOne, the account's password is sent to a [vault](/product/admin/vaults).
+For self-hosted Grafana, when a new account is created by C1, the account's password is sent to a [vault](/product/admin/vaults).
 For Grafana Cloud, account creation is invite-based and no connector-generated password is returned.
 <Note>
 **Grafana Cloud: provisioning organization roles for externally synced users**
 
-In Grafana Cloud, users who sign in through an external identity provider (such as Grafana.com SSO, Okta, Azure AD, or any OAuth/SAML provider) have their organization roles controlled by that provider. By default, Grafana blocks API-level role changes for these users, which prevents ConductorOne from provisioning organization entitlements for them.
+In Grafana Cloud, users who sign in through an external identity provider (such as Grafana.com SSO, Okta, Azure AD, or any OAuth/SAML provider) have their organization roles controlled by that provider. By default, Grafana blocks API-level role changes for these users, which prevents C1 from provisioning organization entitlements for them.
 
-To allow ConductorOne to manage organization roles for these users, enable **Skip org role sync** for the relevant SSO provider in your Grafana instance:
+To allow C1 to manage organization roles for these users, enable **Skip org role sync** for the relevant SSO provider in your Grafana instance:
 
 1. In Grafana, go to **Administration** → **Authentication**.
 2. Select the SSO provider your users log in with.
 3. Enable **Skip org role sync** (equivalent to setting `skip_org_role_sync = true`).
 
-Once this is enabled, Grafana stops overriding org roles on login and ConductorOne becomes the authoritative source for role assignments. This is a global setting that applies to all users under that provider.
+Once this is enabled, Grafana stops overriding org roles on login and C1 becomes the authoritative source for role assignments. This is a global setting that applies to all users under that provider.
 
 This step is not required for self-hosted Grafana instances using basic (username/password) authentication.
 </Note>
@@ -74,17 +74,17 @@ You will need:
 <Warning>
 To complete this task, you'll need:
 
-- The **Connector Administrator** or **Super Administrator** role in ConductorOne
+- The **Connector Administrator** or **Super Administrator** role in C1
 - Access to the set of Grafana credentials gathered by following the instructions above
 </Warning>
 
 <Tabs>
 <Tab title="Cloud-hosted">
-**Follow these instructions to use a built-in, no-code connector hosted by ConductorOne.**
+**Follow these instructions to use a built-in, no-code connector hosted by C1.**
 
 <Steps>
 <Step>
-In ConductorOne, navigate to **Integrations** > **Connectors** and click **Add connector**.
+In C1, navigate to **Integrations** > **Connectors** and click **Add connector**.
 </Step>
 <Step>
 Search for **Grafana** and click **Add**.
@@ -92,16 +92,16 @@ Search for **Grafana** and click **Add**.
 <Step>
 Choose how to set up the new Grafana connector:
 
-   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with ConductorOne)
+   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
 
    - Add the connector to a managed app (select from the list of existing managed apps)
 
    - Create a new managed app
 </Step>
 <Step>
-Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed.
+Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-   If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+   If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
 </Step>
 <Step>
 Click **Next**.
@@ -127,23 +127,23 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Grafana connector is now pulling access data into ConductorOne.
+**That's it!** Your Grafana connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
 **Follow these instructions to use the Grafana connector, hosted and run in your own environment.**
 
-When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with ConductorOne, automatically syncing and uploading data at regular intervals. This data is immediately available in the ConductorOne UI for access reviews and access requests.
+When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with C1, automatically syncing and uploading data at regular intervals. This data is immediately available in the C1 UI for access reviews and access requests.
 
 ### Resources
 
-* [GitHub repository](https://github.com/ConductorOne/baton-grafana): Access the source code, report issues, or contribute to the project.
+* [GitHub repository](https://github.com/conductorone/baton-grafana): Access the source code, report issues, or contribute to the project.
 
 ### Step 1: Set up a new Grafana connector
 
 <Steps>
 <Step>
-In ConductorOne, navigate to **Integrations** > **Connectors** > **Add connector**.
+In C1, navigate to **Integrations** > **Connectors** > **Add connector**.
 </Step>
 <Step>
 Search for **Baton** and click **Add**.
@@ -151,16 +151,16 @@ Search for **Baton** and click **Add**.
 <Step>
 Choose how to set up the new Grafana connector:
 
-   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with ConductorOne)
+   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
 
    - Add the connector to a managed app (select from the list of existing managed apps)
 
    - Create a new managed app
 </Step>
 <Step>
-Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed.
+Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-   If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+   If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
 </Step>
 <Step>
 Click **Next**.
@@ -189,15 +189,15 @@ metadata:
   name: baton-grafana-secrets
 type: Opaque
 stringData:
-  # ConductorOne credentials
-  BATON_CLIENT_ID: <ConductorOne client ID>
-  BATON_CLIENT_SECRET: <ConductorOne client secret>
+  # C1 credentials
+  BATON_CLIENT_ID: <C1 client ID>
+  BATON_CLIENT_SECRET: <C1 client secret>
 
   # Grafana Cloud credentials
   BATON_HOSTNAME: <Grafana Cloud instance URL>       # e.g. https://your-org.grafana.net
   BATON_API_TOKEN: <service account token>
 
-  # Optional: Include if you want ConductorOne to provision access using this connector
+  # Optional: Include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 ```
 
@@ -211,16 +211,16 @@ metadata:
   name: baton-grafana-secrets
 type: Opaque
 stringData:
-  # ConductorOne credentials
-  BATON_CLIENT_ID: <ConductorOne client ID>
-  BATON_CLIENT_SECRET: <ConductorOne client secret>
+  # C1 credentials
+  BATON_CLIENT_ID: <C1 client ID>
+  BATON_CLIENT_SECRET: <C1 client secret>
 
   # Self-hosted Grafana credentials
   BATON_HOSTNAME: <Grafana instance URL>
   BATON_USERNAME: <Grafana account username>
   BATON_PASSWORD: <Grafana account password>
 
-  # Optional: Include if you want ConductorOne to provision access using this connector
+  # Optional: Include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 ```
 
@@ -263,13 +263,13 @@ spec:
 
 <Steps>
 <Step>
-Create a namespace in which to run ConductorOne connectors (if desired), then apply the secret config and deployment config files.
+Create a namespace in which to run C1 connectors (if desired), then apply the secret config and deployment config files.
 </Step>
 <Step>
-Check that the connector data uploaded correctly. In ConductorOne, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Grafana connector to. Grafana data should be found on the **Entitlements** and **Accounts** tabs.
+Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the Grafana connector to. Grafana data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
 
-**That's it!** Your Grafana connector is now pulling access data into ConductorOne.
+**That's it!** Your Grafana connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
Updates `docs/connector.mdx` with the C1 rebrand:

- Renames **ConductorOne** → **C1** in prose, comments, and placeholder text
- Updates brand color `#65DE23` → `#c937ae`
- Lowercases GitHub org name in the repository resource link

URLs that are case-sensitive or functional (distro site, tenant URLs, email addresses, file paths) are unchanged.