### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -55,7 +55,7 @@ You will need:
 * Your Grafana Cloud instance URL (e.g., `https://your-org.grafana.net`)
 * The service account token generated above
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 </Tab>
 <Tab title="Self-hosted Grafana">
 For self-hosted Grafana, the connector authenticates using the username and password of a Grafana admin account.
@@ -65,7 +65,7 @@ You will need:
 * The username and password for a Grafana account with **admin-level permissions**
 * Your Grafana instance URL
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 </Tab>
 </Tabs>
 
@@ -127,7 +127,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Grafana connector is now pulling access data into C1.
+**Done.** Your Grafana connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -270,6 +270,6 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Grafana connector is now pulling access data into C1.
+**Done.** Your Grafana connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.