### PR TITLE
[CXH-2011] docs: document access-origin profile fields for grafana

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -35,6 +35,20 @@ Once this is enabled, Grafana stops overriding org roles on login and C1 becomes
 This step is not required for self-hosted Grafana instances using basic (username/password) authentication.
 </Note>
 
+## Account access origin
+
+Starting with connector version 0.2.3, each synced account's profile includes two attributes that identify how the user's access originated. They appear in the account's **Profile attributes** in C1 and support access reviews where the origin of access matters:
+
+| Attribute | Meaning |
+| :--- | :--- |
+| `is_externally_synced` | `true` when the user's access originates from an external identity provider; `false` for users managed locally in Grafana. |
+| `auth_labels` | The external authentication provider(s) associated with the user (for example, `grafana.com` or an OAuth/SAML provider name), joined with `; ` when there is more than one. This attribute is absent for local users. |
+
+The exact meaning of `is_externally_synced` depends on the connector mode:
+
+* **Grafana Cloud:** the value is Grafana's native `isExternallySynced` flag, meaning the user's organization role is managed by an external identity provider (such as Entra ID or grafana.com SSO).
+* **Self-hosted Grafana:** Grafana's API does not return that flag for the global user list, so the connector derives the value from the user's authentication labels. `true` means the user authenticated through an external module (SSO, LDAP, or OAuth) — slightly broader than role management: a user whose role is managed locally but who signs in through SSO also reports `true`.
+
 ## Gather Grafana credentials
 
 Configuring the connector requires credentials obtained in your Grafana instance. The credentials you need depend on whether you are connecting to **Grafana Cloud** or a **self-hosted Grafana** instance.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -39,10 +39,10 @@ This step is not required for self-hosted Grafana instances using basic (usernam
 
 Starting with connector version 0.2.3, each synced account's profile includes two attributes that identify how the user's access originated. They appear in the account's **Profile attributes** in C1 and support access reviews where the origin of access matters:
 
-| Attribute | Meaning |
-| :--- | :--- |
-| `is_externally_synced` | `true` when the user's access originates from an external identity provider; `false` for users managed locally in Grafana. |
-| `auth_labels` | The external authentication provider(s) associated with the user (for example, `grafana.com` or an OAuth/SAML provider name), joined with `; ` when there is more than one. This attribute is absent for local users. |
+| Attribute | Type | Present | Meaning |
+| :--- | :--- | :--- | :--- |
+| `is_externally_synced` | Boolean | Always | `true` when the user's access originates from an external identity provider; `false` for users managed locally in Grafana. |
+| `auth_labels` | String | Externally authenticated users only | The external authentication provider(s) associated with the user (for example, `grafana.com` or an OAuth/SAML provider name), joined with `; ` when there is more than one. Absent — not an empty string — for local users. |
 
 The exact meaning of `is_externally_synced` depends on the connector mode:
 


### PR DESCRIPTION
## Description
- [ ] Bug fix
- [ ] New feature
- [x] Documentation

Adds an **Account access origin** section to `docs/connector.mdx` documenting the `is_externally_synced` and `auth_labels` account profile attributes shipped in v0.2.3 ([CXH-1711](https://linear.app/ductone/issue/CXH-1711) / PR #73), which were previously undocumented in the repo docs and on the published page.

Covers:
- What each attribute means and where it appears in C1 (account Profile attributes).
- The mode-dependent semantics: Grafana Cloud uses the native `isExternallySynced` flag (org role managed by an external IdP); self-hosted derives the value from `authLabels` (authenticated via an external module — broader than role-sync).
- That `auth_labels` is absent (not empty) for local users, and multi-label joining with `; `.

### Useful links:
- [Linear ticket CXH-2011 — docs: update connector.mdx for grafana](https://linear.app/ductone/issue/CXH-2011)
- [Linear ticket CXH-1711 — the feature this documents](https://linear.app/ductone/issue/CXH-1711)

🤖 Generated with [Claude Code](https://claude.com/claude-code)