### PR TITLE
[CXH-2012] - Return actionable error for Cloud CreateAccount with disabled login form - Grafana Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,24 @@ This information provides insight into user access management in Grafana.
 
 ---
 
+## Account Provisioning
+
+`baton-grafana` supports account provisioning in both self-hosted and Grafana Cloud modes, but the behavior differs:
+
+- **Self-hosted Grafana:** a new user is created directly (`POST /api/admin/users`) and the generated password is returned to ConductorOne.
+- **Grafana Cloud:** account creation is invite-based (`POST /api/org/invites`) and no password is returned.
+
+> **Grafana Cloud prerequisite — the basic login form must allow the invite.**
+> Grafana Cloud instances ship with the basic login form **disabled** by default (users authenticate through grafana.com / SSO). While it is disabled, Grafana rejects instance-level invites for users who do not yet exist in the instance, and account creation fails with `Cannot invite external user when login is disabled.`
+>
+> With the service-account token the connector uses:
+> - **Users who already exist** in the instance (provisioned earlier via SSO, SCIM, or grafana.com) are added to the organization normally.
+> - **Brand-new users** cannot be created until you either enable [SCIM provisioning](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-scim-provisioning/) (Grafana's recommended path for automatic user lifecycle in Cloud) or enable the basic login form (`disable_login_form = false`).
+>
+> Managing membership through the grafana.com portal is a separate API and credential (a Grafana Cloud Access Policy token) that the connector's instance service-account token cannot use.
+
+---
+
 ## Command Line Options
 
 Below is a complete list of supported flags along with their corresponding environment variables and default values (if applicable):

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -19,6 +19,25 @@ The Grafana connector supports [automatic account provisioning and deprovisionin
 
 For self-hosted Grafana, when a new account is created by C1, the account's password is sent to a [vault](/product/admin/vaults).
 For Grafana Cloud, account creation is invite-based and no connector-generated password is returned.
+<Warning>
+**Grafana Cloud: enabling the basic login form is a prerequisite for creating brand-new users**
+
+Grafana Cloud instances ship with the basic login form **disabled** by default (users authenticate through grafana.com / SSO). While it is disabled, Grafana rejects instance-level invites for users who do not yet exist in the instance, and account creation fails with:
+
+```
+Cannot invite external user when login is disabled.
+```
+
+With the service-account token the connector uses, this means:
+
+* **Users who already exist in the instance** (provisioned earlier via SSO, SCIM, or grafana.com) are added to the organization normally — account provisioning works for them without any change.
+* **Brand-new users** cannot be created until you either:
+  * enable [SCIM provisioning](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-scim-provisioning/) (Grafana's recommended path for automatic user lifecycle in Cloud), so users are provisioned by your identity provider before C1 assigns organization roles; or
+  * enable the basic login form on the instance (set `disable_login_form = false`), which permits instance-level invites for external users.
+
+Managing membership directly through the grafana.com portal is a separate API and credential (a Grafana Cloud Access Policy token) that the connector's instance service-account token cannot use.
+</Warning>
+
 <Note>
 **Grafana Cloud: provisioning organization roles for externally synced users**
 

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -1,0 +1,148 @@
+# baton-grafana — Setup Guide
+
+Internal setup and reference guide for the Grafana connector. For the
+customer-facing documentation see [`connector.mdx`](./connector.mdx); connector
+configuration fields live in [`pkg/config/config.go`](../pkg/config/config.go).
+The connector is a hand-written Go connector (native `pkg/grafana` HTTP client
+over the baton-sdk `uhttp` client), not a declarative `baton-http` connector.
+
+The connector supports two deployment modes, selected by the `--auth-method`
+field group:
+
+- **Self-hosted Grafana** (`basic-auth-flow-group`) — Basic auth with an admin
+  username/password; uses the server-admin endpoint set.
+- **Grafana Cloud** (`api-key-flow-group`) — Bearer auth with a service-account
+  token; uses the current-org endpoint set only.
+
+## Connector capabilities
+
+1. **What resources does the connector sync?**
+   - Users — every user visible to the credential (global list in self-hosted;
+     current-org members in Cloud).
+   - Organizations — Grafana organizations and their role grants (Admin, Editor,
+     Viewer).
+
+2. **Can the connector provision any resources? If so, which ones?**
+   - **Accounts (Users)** — `CreateAccount` and `Delete`.
+     - Self-hosted: create via `POST /api/admin/users` (returns a generated
+       password); delete via `DELETE /api/admin/users/{id}`.
+     - Grafana Cloud: create via `POST /api/org/invites` (invite-based, no
+       password returned).
+   - **Organization roles** — `Grant` / `Revoke` of the Admin / Editor / Viewer
+     role on an organization (`POST /api/org/users`, `PATCH /api/org/users/{id}`,
+     `DELETE /api/org/users/{id}` in Cloud; the `/api/orgs/{orgId}/users` variants
+     in self-hosted).
+
+   > **Note (Grafana Cloud account creation).** Cloud instances ship with the
+   > basic login form **disabled** by default. While it is disabled, instance-level
+   > invites for users who do **not** yet exist are rejected with
+   > `Cannot invite external user when login is disabled.` C1 can still add users
+   > who already exist in the instance; brand-new users require SCIM provisioning
+   > or enabling the basic login form. See "Additional notes" below (CXH-2012).
+
+## Connector credentials
+
+1. **What credentials are needed?**
+   - Self-hosted: a Grafana admin **username** + **password**, and the instance
+     **hostname**.
+   - Grafana Cloud: a **service-account token** (Admin role) and the instance
+     **hostname**.
+
+   **Args:**
+
+   | Flag | Env var | Mode | Required |
+   | :--- | :------ | :--- | :------- |
+   | `--hostname` | `BATON_HOSTNAME` | both | yes |
+   | `--auth-method` | `BATON_AUTH_METHOD` | both | selects `basic-auth-flow-group` or `api-key-flow-group` |
+   | `--username` | `BATON_USERNAME` | self-hosted | yes (basic-auth group) |
+   | `--password` | `BATON_PASSWORD` | self-hosted | yes (basic-auth group) |
+   | `--api-token` | `BATON_API_TOKEN` | Grafana Cloud | yes (api-key group) |
+
+2. **For each credential:**
+   - *How does a user create or look up the credential?*
+     - Self-hosted: use an existing Grafana admin login (username/password).
+     - Grafana Cloud: in the instance, go to **Administration → Users and access →
+       Service accounts**, create a service account with the **Admin** role, and
+       add a service-account token.
+   - *Does it need specific scopes/permissions?* Grafana uses a role model, not
+     OAuth scopes. The credential must have **Admin** on the organization(s) being
+     synced/provisioned so it can read users/orgs and manage org membership.
+   - *Different scopes to sync vs provision?* No separate scope — the same Admin
+     role covers read (sync) and write (provisioning). Account creation in Cloud
+     additionally depends on the instance login-form configuration (see notes).
+   - *What access is needed to CREATE the credential?* Org Admin (to create a
+     service-account token) or server admin (self-hosted).
+
+## Resource reference (API doc links)
+
+API doc root: <https://grafana.com/docs/grafana/latest/developers/http_api/>
+
+### Authentication
+
+| Operation | Method + path | Doc |
+| :-------- | :------------ | :-- |
+| Validate (Cloud) | `GET /api/org` | [Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-current-organization) |
+| Validate (self-hosted) | `GET /api/orgs` | [Admin Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#search-all-organizations) |
+
+### Users
+
+| Operation | Method + path | Doc |
+| :-------- | :------------ | :-- |
+| List users (self-hosted) | `GET /api/users` | [User HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/#search-users) |
+| List users (Cloud) | `GET /api/org/users` | [Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-users-in-organization) |
+| Get user by login/email (self-hosted) | `GET /api/users` + client-side match | [User HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/user/#search-users) |
+| Create user (self-hosted) | `POST /api/admin/users` | [Admin HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/admin/#global-users) |
+| Delete user (self-hosted) | `DELETE /api/admin/users/{id}` | [Admin HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/admin/#delete-global-user) |
+| Invite user (Cloud) | `POST /api/org/invites` | [Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#add-invite) |
+
+### Organizations
+
+| Operation | Method + path | Doc |
+| :-------- | :------------ | :-- |
+| List orgs (self-hosted) | `GET /api/orgs` | [Admin Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#search-all-organizations) |
+| List org users | `GET /api/org/users` / `GET /api/orgs/{orgId}/users` | [Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#get-users-in-organization) |
+| Add user to org (role grant) | `POST /api/org/users` / `POST /api/orgs/{orgId}/users` | [Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#add-user-in-organization) |
+| Update org user role | `PATCH /api/org/users/{id}` | [Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#updates-the-given-user) |
+| Remove user from org (revoke) | `DELETE /api/org/users/{id}` / `DELETE /api/orgs/{orgId}/users/{id}` | [Org HTTP API](https://grafana.com/docs/grafana/latest/developers/http_api/org/#delete-user-in-organization) |
+
+## Additional notes
+
+### Grafana Cloud account creation requires an invite-eligible login form (CXH-2012)
+
+In Cloud mode, `CreateAccount` sends an org invite (`POST /api/org/invites`).
+Grafana Cloud instances ship with the basic login form **disabled** by default
+(`disable_login_form = true`; users authenticate via grafana.com / SSO). Grafana
+only enforces this check for users who do **not** already exist in the instance:
+
+- **Existing users** (already provisioned via SSO, SCIM, or grafana.com) are added
+  to the organization normally — the invite path skips the login-form check.
+- **Brand-new external users** are rejected with HTTP 400
+  `Cannot invite external user when login is disabled.`
+
+The connector detects this response (`grafana.ErrExternalUserLoginDisabled`) and
+returns a terminal, actionable error rather than an opaque 400. To provision
+brand-new users, either:
+
+- enable [SCIM provisioning](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-scim-provisioning/)
+  (Grafana's recommended path for automatic user lifecycle in Cloud), so the IdP
+  provisions the user before C1 assigns organization roles; or
+- enable the basic login form on the instance (`disable_login_form = false`).
+
+The grafana.com portal can manage Cloud org membership, but it is a separate API
+(`https://grafana.com/api`) authenticated with a Grafana Cloud Access Policy
+token — a different credential than the instance service-account token the
+connector uses, so it is not an option from within the connector.
+
+### Access origin attributes
+
+Each synced user profile carries `is_externally_synced` and `auth_labels` to
+indicate the origin of the user's access (see `connector.mdx` → "Account access
+origin"). In Cloud the value is Grafana's native `isExternallySynced` flag; in
+self-hosted it is derived from the user's auth labels.
+
+### Org role provisioning for externally synced users
+
+By default Grafana blocks API-level role changes for users whose org role is
+managed by an external IdP. Enable **Skip org role sync** for the relevant SSO
+provider (`skip_org_role_sync = true`) so C1 can manage those roles. This is a
+Cloud-mode consideration; self-hosted basic-auth users are unaffected.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	go.uber.org/zap v1.28.0
 	golang.org/x/text v0.36.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -134,7 +135,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260311181403-84a4fc48630c // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
 	google.golang.org/grpc v1.81.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	go.uber.org/zap v1.28.0
 	golang.org/x/text v0.36.0
+	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -134,7 +135,6 @@ require (
 	golang.org/x/term v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260311181403-84a4fc48630c // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
-	google.golang.org/grpc v1.81.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -38,7 +38,7 @@ func (g *Grafana) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 		Description: "Connector syncing Grafana organizations and users to Baton",
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
-				"full_name": {
+				profileFieldFullName: {
 					DisplayName: "Full Name",
 					Required:    true,
 					Description: "User's full name for display purposes",
@@ -48,7 +48,7 @@ func (g *Grafana) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 					Placeholder: "John Doe",
 					Order:       1,
 				},
-				"email": {
+				profileFieldEmail: {
 					DisplayName: "Email",
 					Required:    true,
 					Description: "User's email address (used for login if username is not provided)",

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -18,6 +18,14 @@ import (
 	"go.uber.org/zap"
 )
 
+// Account-creation profile field keys. These MUST match the keys declared in the
+// AccountCreationSchema field map (see connector.go Metadata) so the values the C1
+// UI / CLI collect reach CreateAccount.
+const (
+	profileFieldEmail    = "email"
+	profileFieldFullName = "full_name"
+)
+
 type userBuilder struct {
 	resourceType *v2.ResourceType
 	client       *grafana.Client
@@ -207,7 +215,7 @@ func (u *userBuilder) CreateAccount(
 	l := ctxzap.Extract(ctx)
 
 	// Extract user information from profile — common to both modes
-	emailVal := accountInfo.Profile.GetFields()["email"]
+	emailVal := accountInfo.Profile.GetFields()[profileFieldEmail]
 	if emailVal == nil || emailVal.GetStringValue() == "" {
 		return nil, nil, nil, fmt.Errorf("grafana-connector: email is required for account creation")
 	}
@@ -215,7 +223,7 @@ func (u *userBuilder) CreateAccount(
 
 	// Get full name from profile or use email as fallback
 	name := email
-	if nameVal := accountInfo.Profile.GetFields()["full_name"]; nameVal != nil && nameVal.GetStringValue() != "" {
+	if nameVal := accountInfo.Profile.GetFields()[profileFieldFullName]; nameVal != nil && nameVal.GetStringValue() != "" {
 		name = nameVal.GetStringValue()
 	}
 
@@ -253,6 +261,17 @@ func (u *userBuilder) createAccountCloud(
 
 	inviteResp, err := u.client.InviteUserToOrg(ctx, inviteReq)
 	if err != nil {
+		// Grafana Cloud disables the basic login form by default, so instance-level
+		// invites for brand-new external users are rejected. Surface an actionable
+		// error: C1 can only add users that already exist in the instance (provisioned
+		// via SSO / SCIM / grafana.com); creating new users requires SCIM provisioning
+		// or enabling the basic login form.
+		if errors.Is(err, grafana.ErrExternalUserLoginDisabled) {
+			return nil, nil, nil, fmt.Errorf(
+				"grafana-connector: cloud: cannot provision new user %q because the instance's basic login form is disabled (the Grafana Cloud default); "+
+					"C1 can only add users that already exist in this instance (provisioned via SSO/SCIM/grafana.com) — to create new users, enable SCIM provisioning or the basic login form: %w",
+				email, err)
+		}
 		return nil, nil, nil, fmt.Errorf("grafana-connector: cloud: failed to invite user: %w", err)
 	}
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -14,8 +14,10 @@ import (
 	"github.com/conductorone/baton-sdk/pkg/crypto"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
 )
 
 // Account-creation profile field keys. These MUST match the keys declared in the
@@ -267,10 +269,17 @@ func (u *userBuilder) createAccountCloud(
 		// via SSO / SCIM / grafana.com); creating new users requires SCIM provisioning
 		// or enabling the basic login form.
 		if errors.Is(err, grafana.ErrExternalUserLoginDisabled) {
-			return nil, nil, nil, fmt.Errorf(
-				"grafana-connector: cloud: cannot provision new user %q because the instance's basic login form is disabled (the Grafana Cloud default); "+
-					"C1 can only add users that already exist in this instance (provisioned via SSO/SCIM/grafana.com) — to create new users, enable SCIM provisioning or the basic login form: %w",
-				email, err)
+			// Terminal, non-retryable: a configuration prerequisite, not a transient
+			// failure. WrapErrors attaches an explicit InvalidArgument gRPC status so
+			// the platform surfaces the prerequisite instead of retrying, while the
+			// errors.Join chain keeps ErrExternalUserLoginDisabled unwrappable.
+			return nil, nil, nil, uhttp.WrapErrors(
+				codes.InvalidArgument,
+				fmt.Sprintf(
+					"grafana-connector: cloud: cannot provision new user %q because the instance's basic login form is disabled (the Grafana Cloud default); "+
+						"C1 can only add users that already exist in this instance (provisioned via SSO/SCIM/grafana.com) — to create new users, enable SCIM provisioning or the basic login form",
+					email),
+				err)
 		}
 		return nil, nil, nil, fmt.Errorf("grafana-connector: cloud: failed to invite user: %w", err)
 	}

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -2,14 +2,17 @@ package connector
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/conductorone/baton-grafana/pkg/grafana"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestListCloud_CreatesUserResources(t *testing.T) {
@@ -75,6 +78,41 @@ func TestListCloud_DisabledUserHasDisabledStatus(t *testing.T) {
 	}
 	if userTrait.GetStatus().GetStatus() != v2.UserTrait_Status_STATUS_DISABLED {
 		t.Errorf("expected STATUS_DISABLED for disabled user, got %v", userTrait.GetStatus().GetStatus())
+	}
+}
+
+// TestCreateAccountCloud_LoginDisabledReturnsActionableError reproduces CXH-2012:
+// a default-configuration Grafana Cloud instance (basic login form disabled) rejects
+// invites for brand-new external users with HTTP 400. The connector must surface an
+// actionable error tagged with grafana.ErrExternalUserLoginDisabled, not an opaque 400.
+func TestCreateAccountCloud_LoginDisabledReturnsActionableError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/org/invites", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusBadRequest, grafana.GrafanaError{
+			ErrorMessage: "Cannot invite external user when login is disabled.",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	profile, err := structpb.NewStruct(map[string]interface{}{
+		profileFieldEmail:    "qa.probe@example.com",
+		profileFieldFullName: "QA Probe",
+	})
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+
+	builder := newUserBuilder(newCloudClientForTest(t, ts))
+	_, _, _, err = builder.CreateAccount(context.Background(), &v2.AccountInfo{Profile: profile}, nil)
+	if err == nil {
+		t.Fatal("expected CreateAccount to fail when login is disabled, got nil error")
+	}
+	if !errors.Is(err, grafana.ErrExternalUserLoginDisabled) {
+		t.Errorf("expected error to wrap grafana.ErrExternalUserLoginDisabled, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "SCIM") {
+		t.Errorf("expected actionable error mentioning SCIM, got %v", err)
 	}
 }
 

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -95,9 +95,9 @@ func TestCreateAccountCloud_LoginDisabledReturnsActionableError(t *testing.T) {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	profile, err := structpb.NewStruct(map[string]interface{}{
-		profileFieldEmail:    "qa.probe@example.com",
-		profileFieldFullName: "QA Probe",
+	profile, err := structpb.NewStruct(map[string]any{
+		profileFieldEmail:    "jane.doe@example.com",
+		profileFieldFullName: "Jane Doe",
 	})
 	if err != nil {
 		t.Fatalf("structpb.NewStruct: %v", err)
@@ -113,6 +113,38 @@ func TestCreateAccountCloud_LoginDisabledReturnsActionableError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "SCIM") {
 		t.Errorf("expected actionable error mentioning SCIM, got %v", err)
+	}
+}
+
+// TestCreateAccountCloud_Non400WithSameMessageIsNotTagged guards the 400 status
+// gate: an error that carries the "login is disabled" phrase but is NOT a 400
+// (e.g. a 500) must fall through to the generic path, not be mis-tagged as
+// ErrExternalUserLoginDisabled.
+func TestCreateAccountCloud_Non400WithSameMessageIsNotTagged(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/org/invites", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusInternalServerError, grafana.GrafanaError{
+			ErrorMessage: "Cannot invite external user when login is disabled.",
+		})
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	profile, err := structpb.NewStruct(map[string]any{
+		profileFieldEmail:    "jane.doe@example.com",
+		profileFieldFullName: "Jane Doe",
+	})
+	if err != nil {
+		t.Fatalf("structpb.NewStruct: %v", err)
+	}
+
+	builder := newUserBuilder(newCloudClientForTest(t, ts))
+	_, _, _, err = builder.CreateAccount(context.Background(), &v2.AccountInfo{Profile: profile}, nil)
+	if err == nil {
+		t.Fatal("expected CreateAccount to fail on a 500, got nil error")
+	}
+	if errors.Is(err, grafana.ErrExternalUserLoginDisabled) {
+		t.Errorf("a non-400 error must not be tagged ErrExternalUserLoginDisabled, got %v", err)
 	}
 }
 

--- a/pkg/connector/users_test.go
+++ b/pkg/connector/users_test.go
@@ -12,6 +12,8 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/pagination"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -113,6 +115,11 @@ func TestCreateAccountCloud_LoginDisabledReturnsActionableError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "SCIM") {
 		t.Errorf("expected actionable error mentioning SCIM, got %v", err)
+	}
+	// The failure is a terminal configuration prerequisite: the platform must see
+	// InvalidArgument (non-retryable), not an opaque codes.Unknown from a bare fmt.Errorf.
+	if code := status.Code(err); code != codes.InvalidArgument {
+		t.Errorf("expected gRPC status codes.InvalidArgument, got %v", code)
 	}
 }
 

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -428,9 +428,12 @@ func (c *Client) InviteUserToOrg(ctx context.Context, req *InviteUserRequest) (*
 	err := c.doRequest(ctx, http.MethodPost, c.buildResourceURL(InviteUserPath), &resp, req, nil)
 	if err != nil {
 		// Grafana rejects invites for brand-new external users when the basic
-		// login form is disabled (the Grafana Cloud default). Tag it so the
-		// connector can surface an actionable error instead of a raw 400.
-		if strings.Contains(err.Error(), "login is disabled") {
+		// login form is disabled (the Grafana Cloud default). Gate on the 400
+		// status (like the 412 check for ErrUserAlreadyExists) plus the message
+		// so an unrelated error carrying the same phrase isn't mis-tagged; a
+		// reworded message just falls through to the generic error below.
+		if strings.Contains(err.Error(), fmt.Sprintf("%d", http.StatusBadRequest)) &&
+			strings.Contains(err.Error(), "login is disabled") {
 			return nil, fmt.Errorf("%w: %w", ErrExternalUserLoginDisabled, err)
 		}
 		return nil, fmt.Errorf("grafana-client: invite user to org: %w", err)

--- a/pkg/grafana/client.go
+++ b/pkg/grafana/client.go
@@ -36,6 +36,14 @@ const (
 // ErrUserAlreadyExists is returned when attempting to create a user that already exists in Grafana.
 var ErrUserAlreadyExists = errors.New("grafana-client: user already exists")
 
+// ErrExternalUserLoginDisabled is returned when POST /api/org/invites rejects a
+// brand-new external user because the instance's basic login form is disabled.
+// This is the Grafana Cloud default (users authenticate via SSO / grafana.com),
+// so instance-level invites for non-existing users are rejected with HTTP 400
+// "Cannot invite external user when login is disabled." Existing users are added
+// to the org without hitting this check.
+var ErrExternalUserLoginDisabled = errors.New("grafana-client: cannot invite external user when login is disabled")
+
 // NewClient initializes a new Grafana API client.
 // When apiToken is non-empty the client operates in Cloud mode (Bearer auth).
 // When apiToken is empty the client operates in self-hosted mode (Basic auth).
@@ -419,6 +427,12 @@ func (c *Client) InviteUserToOrg(ctx context.Context, req *InviteUserRequest) (*
 
 	err := c.doRequest(ctx, http.MethodPost, c.buildResourceURL(InviteUserPath), &resp, req, nil)
 	if err != nil {
+		// Grafana rejects invites for brand-new external users when the basic
+		// login form is disabled (the Grafana Cloud default). Tag it so the
+		// connector can surface an actionable error instead of a raw 400.
+		if strings.Contains(err.Error(), "login is disabled") {
+			return nil, fmt.Errorf("%w: %w", ErrExternalUserLoginDisabled, err)
+		}
 		return nil, fmt.Errorf("grafana-client: invite user to org: %w", err)
 	}
 


### PR DESCRIPTION
## Description
- [x] Bug fix
- [ ] New feature

Fixes [CXH-2012](https://linear.app/ductone/issue/CXH-2012). In Grafana **Cloud** mode, `CreateAccount` provisions users via an org invite (`POST /api/org/invites`). Grafana Cloud instances ship with the basic login form **disabled** by default (users authenticate via grafana.com / SSO), and in that state Grafana rejects invites for brand-new external users with `400 Cannot invite external user when login is disabled`. The connector surfaced this as an opaque `InvalidArgument: 400 Bad Request`, so the declared `CAPABILITY_ACCOUNT_PROVISIONING` looked broken against the default configuration of the mode it targets.

Investigation (docs + Grafana source + a live default-config Cloud instance) confirmed this is *impossible-as-credentialed* for brand-new users with the instance service-account token: `/api/admin/users` needs server-admin (a service account can't hold it), and the grafana.com portal API is a different credential realm (a Cloud Access Policy token). The one case that *does* work is adding a user who already exists in the instance — Grafana's invite path skips the login-form check for existing users. So the fix makes the failure **legible and actionable** rather than pretending a path exists.

### Sync:

- **Users** (`user`) — unchanged surface.
- **Organizations** (`org`) — unchanged surface.

### Provisioning:

- **Create user accounts (Grafana Cloud)** — when the invite is rejected because the basic login form is disabled, `createAccountCloud` now returns a **terminal, actionable error** (tagged `grafana.ErrExternalUserLoginDisabled`) explaining that C1 can only add users that already exist in the instance (provisioned via SSO/SCIM/grafana.com), and that creating brand-new users requires SCIM provisioning or enabling the basic login form. The gRPC code stays `InvalidArgument` (terminal, non-retryable — a configuration prerequisite, not a transient failure).
- **Create user accounts (self-hosted)** — unchanged.
- **Delete user accounts** — unchanged.
- **Grant/Revoke organization roles** — unchanged.

### Auth:

Unchanged. No new config flags. Cloud mode keeps using the service-account token (`--api-token` / `api-key-flow-group`); self-hosted keeps Basic auth.

### Architecture highlights:

- New client sentinel `grafana.ErrExternalUserLoginDisabled`, detected in `InviteUserToOrg` via `strings.Contains(err.Error(), "login is disabled")` — mirrors the existing `ErrUserAlreadyExists` (412) detection and `fmt.Errorf("%w: %w", …)` wrapping already used in the client.
- Extracted the account-creation profile field keys into shared constants (`profileFieldEmail`, `profileFieldFullName`) used by both the `AccountCreationSchema` in `Metadata()` and the `CreateAccount` reads, so the schema keys and the read keys cannot drift.
- **Docs:** documented the Cloud prerequisite in `docs/connector.mdx` (a `<Warning>` block), added an **Account Provisioning** section to `README.md`, and created `docs/docs-info.md` (the connector had none) — an internal setup guide with capabilities/credentials Q&A and a per-resource endpoint reference.
- Validated against a live default-config Grafana Cloud instance (`disableLoginForm: true`): the exact ticket repro now returns the actionable error and creates nothing, and a full sync still completes cleanly.

### Useful links:

- [Linear ticket CXH-2012 — Cloud-mode CreateAccount fails on default Grafana Cloud](https://linear.app/ductone/issue/CXH-2012)
- [Grafana Org HTTP API — Add invite](https://grafana.com/docs/grafana/latest/developers/http_api/org/#add-invite)
- [Grafana Cloud SCIM provisioning](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-scim-provisioning/)
- [Grafana `disable_login_form` setting](https://grafana.com/docs/grafana/latest/setup-grafana/configure-access/configure-authentication/grafana/)
